### PR TITLE
ENG-3480 use networking.k8s.io/v1 api group instead of extensions/v1b…

### DIFF
--- a/Dockerfile.jvm
+++ b/Dockerfile.jvm
@@ -1,4 +1,4 @@
-FROM entando/entando-k8s-operator-common:7.0.0-ENG-3478-PR-97
+FROM entando/entando-k8s-operator-common:7.0.1-ENG-3480-PR-96
 ARG VERSION
 LABEL name="Entando K8S App Plugin Link Controller" \
       vendor="Entando" \

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <github.organization>entando-k8s</github.organization>
         <sonar.projectKey>${github.organization}_${project.artifactId}</sonar.projectKey>
-        <entando-k8s-operator-common.version>7.0.0-ENG-3478-PR-97</entando-k8s-operator-common.version>
+        <entando-k8s-operator-common.version>7.0.1-ENG-3480-PR-96</entando-k8s-operator-common.version>
         <preDeploymentTestGroups>in-process</preDeploymentTestGroups>
         <postDeploymentTestGroups>smoke</postDeploymentTestGroups>
         <skipLicenseDownload>true</skipLicenseDownload>

--- a/src/main/java/org/entando/kubernetes/controller/link/support/LinkCommand.java
+++ b/src/main/java/org/entando/kubernetes/controller/link/support/LinkCommand.java
@@ -17,7 +17,7 @@
 package org.entando.kubernetes.controller.link.support;
 
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import java.util.Objects;
 import java.util.Optional;
 import org.entando.kubernetes.controller.spi.client.SerializedEntandoResource;

--- a/src/test/java/org/entando/kubernetes/controller/link/LinkControllerTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/link/LinkControllerTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Issue;
@@ -80,8 +80,8 @@ class LinkControllerTest extends LinkControllerTestBase {
         step("When I link the EntandoApp to the EntandoPlugin", this::processLink);
         step("Then the main web context path of the EntandoPlugin is exposed on the EntandoApps' ingress", () -> {
             Ingress ingress = getClient().ingresses().loadIngress(MY_NAMESPACE, NameUtils.standardIngressName(entandoApp));
-            assertThat(theHttpPath("/my-plugin-context").on(ingress).getBackend().getServiceName()).isEqualTo("my-plugin-service");
-            assertThat(theHttpPath("/my-plugin-context").on(ingress).getBackend().getServicePort().getIntVal()).isEqualTo(8081);
+            assertThat(theHttpPath("/my-plugin-context").on(ingress).getBackend().getService().getName()).isEqualTo("my-plugin-service");
+            assertThat(theHttpPath("/my-plugin-context").on(ingress).getBackend().getService().getPort().getNumber()).isEqualTo(8081);
         });
         step("And the SSO Client for boths the EntandoAppServer and EntandoComponentManager have been given the 'entandApp' role on the "
                         + "EntandoPlugin's SSO cleint",
@@ -122,9 +122,9 @@ class LinkControllerTest extends LinkControllerTestBase {
         step("When I link the EntandoApp to the EntandoPlugin", this::processLink);
         step("Then the main web context path of the EntandoPlugin is exposed on the EntandoApps' ingress", () -> {
             Ingress ingress = getClient().ingresses().loadIngress(MY_NAMESPACE, NameUtils.standardIngressName(entandoApp));
-            assertThat(theHttpPath("/my-plugin-context").on(ingress).getBackend().getServiceName())
+            assertThat(theHttpPath("/my-plugin-context").on(ingress).getBackend().getService().getName())
                     .isEqualTo("my-app-ingress-to-my-plugin-service");
-            assertThat(theHttpPath("/my-plugin-context").on(ingress).getBackend().getServicePort().getIntVal()).isEqualTo(8081);
+            assertThat(theHttpPath("/my-plugin-context").on(ingress).getBackend().getService().getPort().getNumber()).isEqualTo(8081);
         });
         step("And the SSO Client for boths the EntandoAppServer and EntandoComponentManager have been given the 'entandApp' role on the "
                         + "EntandoPlugin's SSO cleint",


### PR DESCRIPTION
…eta1 for the created ingresses